### PR TITLE
Lock Parse SDK to last known working version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "parse-community/Parse-SDK-iOS-OSX"
+github "parse-community/Parse-SDK-iOS-OSX" == 1.15.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "BoltsFramework/Bolts-ObjC" "1.8.4"
+github "BoltsFramework/Bolts-ObjC" "1.9.0"
 github "parse-community/Parse-SDK-iOS-OSX" "1.15.2"


### PR DESCRIPTION
When updating Parse I found that with Parse SDK v1.16 installed, the
 app crashed on launch. The login VC parent class
 "PFLoginViewController" was no longer available after ParseUI was
 deprecated. Other users in an issue on GitHub said it worked after
 changing import statements from "#import <ParseUI/ParseUI.h>" to
 "@import Parse;", but I was still unable to launch the app after
 trying this and several other things.
I've updated the Cartfile to require Parse SDK v1.15.2 - this older
 version will be fine to use until we switch to iCloud for our backend.